### PR TITLE
fix: use visibility property for validation messages

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -86,13 +86,13 @@ body {
 }
 
 .input-group .msg {
-  display: none;
+  visibility: hidden;
   font-size: .75rem;
 }
 
 .input-group.success .msg,
 .input-group.error .msg {
-  display: block;
+  visibility: visible;
 }
 
 .input-group.error .msg {


### PR DESCRIPTION
I used `visibility: visible` and `visibility: hidden` for the validation messages instead of `display: none` and `display: block`.

Using the latter affects the page's structure which you didn't want when you used `box-shadow` instead of a `border` when you're focused on the input fields.